### PR TITLE
Delete old app before deploying new one

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Azure delete old Static Website
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob delete-batch --pattern '*' --account-name coiteu --auth-mode key -s '$web'
       - name: Azure deploy Static Website
         uses: azure/CLI@v1
         with:


### PR DESCRIPTION
When deploying a new version of the app to azure via the main pipeline, an azure cli command gets executed which deletes all files from the old app before copying the new one.

closes #29 