### PR TITLE
Irrelevanter Pro-Tipp auf mobilen Geräten

### DIFF
--- a/libs/ui/src/lib/navigation/navigation.component.scss
+++ b/libs/ui/src/lib/navigation/navigation.component.scss
@@ -56,7 +56,7 @@ nav {
 }
 
 .hotkey-hint {
-  display: flex;
+  display: none;
   gap: 0.25em;
   line-height: 1;
   font-size: small;
@@ -78,5 +78,9 @@ nav {
     background-size: auto;
     background-repeat: no-repeat;
     background-position: right;
+  }
+
+  .hotkey-hint {
+    display: flex;
   }
 }


### PR DESCRIPTION
Der Hotkey Hinweis wird auf mobilen Geräten nicht angezeigt.

closes #68 