### PR TITLE
fix: grow glass box on mobile

### DIFF
--- a/libs/sites/src/lib/solutions-page/solutions-page.component.scss
+++ b/libs/sites/src/lib/solutions-page/solutions-page.component.scss
@@ -13,7 +13,7 @@ section {
 
 .solutions-page__example-video-player {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
 
   width: 100%;
   --youtube-player-width: calc(100% - 2em);

--- a/libs/ui/src/themes/core/_layout.scss
+++ b/libs/ui/src/themes/core/_layout.scss
@@ -34,12 +34,11 @@ $mobile-size: 48rem;
 .columns-auto {
   grid-gap: 2em 1.5em;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12em, 18em));
-
+  grid-template-columns: repeat(auto-fit, minmax(12em, 21.5em));
   grid-auto-rows: 1fr;
-
   row-gap: 2em;
   column-gap: 1.5em;
+  justify-content: center;
 }
 
 .columns-auto--xl {
@@ -54,7 +53,7 @@ $mobile-size: 48rem;
 
 @media only screen and (min-width: 48rem) {
   .columns {
-    grid-gap: 2em;
+    grid-gap: 5em;
     grid-auto-columns: 1fr;
     grid-auto-flow: column;
     align-items: center;
@@ -72,7 +71,13 @@ $mobile-size: 48rem;
     grid-template-columns: 1fr 1fr 1fr;
     align-items: start;
   }
+
+  .columns-auto {
+    justify-content: flex-start;
+    grid-template-columns: repeat(auto-fit, minmax(12em, 18em));
+  }
 }
+
 
 .center-content {
   display: grid;

--- a/libs/ui/src/themes/core/_typography.scss
+++ b/libs/ui/src/themes/core/_typography.scss
@@ -104,6 +104,14 @@ h1 {
   }
 }
 
+@media only screen and (min-width: 48rem) {
+  .text-box-glass {
+    p {
+      max-width: 20em;
+    }
+  }
+}
+
 .text-box-glass {
   border-radius: 8px;
   background: linear-gradient(
@@ -119,7 +127,7 @@ h1 {
     font-size: 1.6em;
     line-height: 1.4em;
     color: var(--blue-ocean);
-    max-width: 20em;
+    max-width: 48em;
   }
 
   a {

--- a/libs/ui/src/themes/overrides/youtube-player.scss
+++ b/libs/ui/src/themes/overrides/youtube-player.scss
@@ -3,7 +3,7 @@
   display: flex;
   width: var(--youtube-player-width);
   aspect-ratio: 16/9;
-  justify-content: flex-end;
+  justify-content: center;
 
   > iframe {
     display: block;


### PR DESCRIPTION
- gap zwischen den gridelementen vergrößert
- umbruch bei "mobile-breakpoint" (48rem), content zentriert
- text in der glass box breiter