### PR TITLE
Fix/add link icon to every content

### DIFF
--- a/libs/ui/src/themes/core/_typography.scss
+++ b/libs/ui/src/themes/core/_typography.scss
@@ -127,7 +127,7 @@ h1 {
 }
 
 /*
-   * Each link in markdown content is suffixed with a chain icon
+   * Each link in markdown content is prefixed with a chain icon
    * The icon needs to be copied to the assets folder.
    * With Angular CLI wie can do this in the project.json.
    *


### PR DESCRIPTION
- icon an alle links im markdown angefügt
- farbe des icons wird anhand der aktuell gewählte textfarbe gesetzt