### PR TITLE
Footer Mobile Layout

### DIFF
--- a/libs/ui/src/lib/footer/footer.component.scss
+++ b/libs/ui/src/lib/footer/footer.component.scss
@@ -8,7 +8,9 @@
 
 .content {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+  gap: 1em;
 }
 
 .links {
@@ -48,4 +50,11 @@
   border-style: solid;
   border-width: 0 0 2.5em 100vw;
   border-color: transparent transparent var(--primary-color) transparent;
+}
+
+@media only screen and (min-width: 54rem) {
+  .content {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
Auf mobile Geräten werden die Link-Icons im Footer in eine neue Zeile verschoben. Dadurch verdeckt der Scroll-To-Top-Button nicht die Icons.

closes #109 