### PR TITLE
Hero-Text Mobile

### DIFF
--- a/libs/career/recruiting-process/src/lib/recruiting-process.component.scss
+++ b/libs/career/recruiting-process/src/lib/recruiting-process.component.scss
@@ -22,3 +22,9 @@
 .recruiting-process__hero-text-section {
   padding: 2em 0;
 }
+
+@media only screen and (max-width: 54rem){
+  .recruiting-process__hero-text-section {
+    display: none;
+  }
+}


### PR DESCRIPTION
Hero-Text auf Karriereseite auf mobilen Geräten entfernt.

closes #107 